### PR TITLE
Let unfinished doodles persist when not actively doodling

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -775,6 +775,7 @@ export default class Guest extends Delegator {
         $doodle: true,
         doodleLines: this.doodleCanvasController.lines,
       });
+      this.doodleCanvasController.lines = [];
     }
   }
 }

--- a/src/doodle/doodleCanvas.js
+++ b/src/doodle/doodleCanvas.js
@@ -1,5 +1,5 @@
 import { createElement } from 'preact';
-import { useState } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import { Canvas } from './canvas';
 import propTypes from 'prop-types';
 
@@ -31,6 +31,28 @@ const DoodleCanvas = ({
   setLines,
 }) => {
   const [isDrawing, setIsDrawing] = useState(false);
+  const [everActive, setEverActive] = useState(false);
+
+  if (active && !everActive) {
+    setEverActive(true);
+  }
+
+  useEffect(() => {
+    if (lines.length === 0) {
+      return () => {};
+    }
+    const warn = e => {
+      e = e || window.event;
+
+      e.preventDefault();
+      e.returnValue = '';
+      return '';
+    };
+    window.addEventListener('beforeunload', warn);
+    return () => {
+      window.removeEventListener('beforeunload', warn);
+    };
+  }, [lines]);
 
   const handleMouseDown = e => {
     setIsDrawing(true);
@@ -74,7 +96,7 @@ const DoodleCanvas = ({
     setLines([newLine, ...rest]);
   };
 
-  if (!active) {
+  if (!everActive) {
     return null;
   }
 


### PR DESCRIPTION
The variable in doodleCanvas to track "everActive" was introduced as trying to render the canvas immediately caused strange issues, like preventing the Objects of Affection page from loading at all. This way, we can wait to render the canvas until the user interacts with Hypothesis to open it, which can only happen after the page finishes loading. 

The useEffect is to give the "changes you made may not be saved" message if they have an unsaved doodle. Since this isn't well standardized, we need to signal that the message should be displayed in 3 different ways. Kind of awkward, but it's probably not worth bringing in a full library to simplify.

Saving a doodle now clears the canvas, making it completely disappear (for now). This is to get the "changes you made may not be saved message" to not appear once they've saved the doodle, along with letting them create other doodles without keeping all their old work around. Once @WiFuchs finishes his task, it can then be re-displayed as an existing doodle.