### PR TITLE
Make doodles not orphans

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -498,12 +498,15 @@ export default class Guest extends Delegator {
         }
       }
       annotation.$orphan = hasAnchorableTargets && !hasAnchoredTargets;
+      //WILLNOTE why is this `undefined` when all of the annotations are being counted? Orphans is set properly!
+      // An annotation is a doodle if any of its selectors have the type 'DoodleSelector'
       annotation.$doodle = anchors.some(a => {
         return (
           a.target && a.target.selector?.some(s => s.type === 'DoodleSelector')
         );
       });
 
+      // Display the doodle on the canvas
       if (annotation.$doodle) {
         this.loadDoodle(annotation);
       }

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -807,12 +807,11 @@ export default class Guest extends Delegator {
   }
 
   loadDoodle(doodleAnnotation) {
-    // First, make sure there are doodleAnnotations and a Controller
     if (!this.doodleCanvasController) {
       return;
     }
 
-    // Then, load the lines into our doodleCanvasController.
+    //load the lines into our doodleCanvasController.
     let newLines = [];
     for (let targ of doodleAnnotation.target) {
       for (let sel of targ.selector) {

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -498,7 +498,6 @@ export default class Guest extends Delegator {
         }
       }
       annotation.$orphan = hasAnchorableTargets && !hasAnchoredTargets;
-      //WILLNOTE why is this `undefined` when all of the annotations are being counted? Orphans is set properly!
       // An annotation is a doodle if any of its selectors have the type 'DoodleSelector'
       annotation.$doodle = anchors.some(a => {
         return (

--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -306,8 +306,7 @@ export default class Guest extends Delegator {
     });
 
     this.subscribe('annotationsLoaded', annotations => {
-      this.loadDoodles(annotations.filter(this.isDoodleAnnotation));
-      annotations.map(annotation => this.anchor(annotation));
+      annotations.forEach(annotation => this.anchor(annotation));
     });
   }
 
@@ -499,6 +498,15 @@ export default class Guest extends Delegator {
         }
       }
       annotation.$orphan = hasAnchorableTargets && !hasAnchoredTargets;
+      annotation.$doodle = anchors.some(a => {
+        return (
+          a.target && a.target.selector?.some(s => s.type === 'DoodleSelector')
+        );
+      });
+
+      if (annotation.$doodle) {
+        this.loadDoodle(annotation);
+      }
 
       // Add the anchors for this annotation to instance storage.
       this.anchors = this.anchors.concat(anchors);
@@ -796,43 +804,18 @@ export default class Guest extends Delegator {
     }
   }
 
-  /**
-   *
-   * @param {*} annotation
-   * @returns true if the annotation is a doodleAnnotation
-   */
-
-  isDoodleAnnotation(annotation) {
-    // If any of the targets have a DoodleSelector, this is a doodle annotation. Otherwise, it is not.
-    if (annotation.target) {
-      for (let targ of annotation.target) {
-        // not all targets have selectors at this point
-        if (targ.selector) {
-          for (let selector of targ.selector) {
-            if (selector.type === 'DoodleSelector') {
-              return true;
-            }
-          }
-        }
-      }
-    }
-    return false;
-  }
-
-  loadDoodles(doodleAnnotations) {
+  loadDoodle(doodleAnnotation) {
     // First, make sure there are doodleAnnotations and a Controller
-    if (!doodleAnnotations.length || !this.doodleCanvasController) {
+    if (!this.doodleCanvasController) {
       return;
     }
 
     // Then, load the lines into our doodleCanvasController.
     let newLines = [];
-    for (let doodle of doodleAnnotations) {
-      for (let targ of doodle.target) {
-        for (let sel of targ.selector) {
-          if (sel.type === 'DoodleSelector') {
-            newLines = [...newLines, sel.line];
-          }
+    for (let targ of doodleAnnotation.target) {
+      for (let sel of targ.selector) {
+        if (sel.type === 'DoodleSelector') {
+          newLines = [...newLines, sel.line];
         }
       }
     }

--- a/src/annotator/test/guest-test.js
+++ b/src/annotator/test/guest-test.js
@@ -206,36 +206,6 @@ describe('Guest', () => {
         assert.calledWith(guest.anchor, ann2);
       });
 
-      it('calls loadDoodles with only doodle annotations on "annotationsLoaded"', () => {
-        const ann1 = {
-          id: 1,
-          $tag: 'tag1',
-          target: [
-            {
-              selector: [
-                {
-                  type: 'DoodleSelector',
-                  line: {
-                    points: [
-                      [1, 1],
-                      [2, 2],
-                    ],
-                    size: 5,
-                    color: '#FF0000',
-                    tool: 'pen',
-                  },
-                },
-              ],
-            },
-          ],
-        };
-        const ann2 = { id: 2, $tag: 'tag2' };
-        sandbox.stub(guest, 'anchor');
-        options.emit('annotationsLoaded', [ann1, ann2]);
-        assert.calledOnce(guest.loadDoodles);
-        assert.calledWith(guest.loadDoodles, [ann1]);
-      });
-
       it('proxies all other events into the annotator event system', () => {
         const fooHandler = sandbox.stub();
         const barHandler = sandbox.stub();
@@ -689,6 +659,36 @@ describe('Guest', () => {
       return guest
         .anchor(annotation)
         .then(() => assert.isFalse(annotation.$orphan));
+    });
+
+    it('marks an annotation with DoodleSelectors as a doodle', () => {
+      const guest = createGuest();
+      const annotation = {
+        id: 1,
+        $tag: 'tag1',
+        target: [
+          {
+            selector: [
+              {
+                type: 'DoodleSelector',
+                line: {
+                  points: [
+                    [1, 1],
+                    [2, 2],
+                  ],
+                  size: 5,
+                  color: '#FF0000',
+                  tool: 'pen',
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      return guest
+        .anchor(annotation)
+        .then(() => assert.isTrue(annotation.$doodle));
     });
 
     it("doesn't mark an annotation with a selectorless target as an orphan", () => {

--- a/src/sidebar/components/SelectionTabs.js
+++ b/src/sidebar/components/SelectionTabs.js
@@ -96,6 +96,7 @@ function SelectionTabs({ isLoading, settings }) {
   const noteCount = store.noteCount();
   const annotationCount = store.annotationCount();
   const orphanCount = store.orphanCount();
+  const doodleCount = store.doodleCount();
   const isWaitingToAnchorAnnotations = store.isWaitingToAnchorAnnotations();
 
   /**
@@ -143,6 +144,17 @@ function SelectionTabs({ isLoading, settings }) {
             onSelect={() => selectTab('orphan')}
           >
             Orphans
+          </Tab>
+        )}
+        {doodleCount > 0 && (
+          <Tab
+            count={doodleCount}
+            isWaitingToAnchor={isWaitingToAnchorAnnotations}
+            isSelected={selectedTab === 'doodle'}
+            label="Doodles"
+            onSelect={() => selectTab('doodle')}
+          >
+            Doodles
           </Tab>
         )}
       </div>

--- a/src/sidebar/components/test/SelectionTabs-test.js
+++ b/src/sidebar/components/test/SelectionTabs-test.js
@@ -33,6 +33,7 @@ describe('SelectionTabs', function () {
       annotationCount: sinon.stub().returns(123),
       noteCount: sinon.stub().returns(456),
       orphanCount: sinon.stub().returns(0),
+      doodleCount: sinon.stub().returns(1),
       isWaitingToAnchorAnnotations: sinon.stub().returns(false),
       selectedTab: sinon.stub().returns('annotation'),
     };
@@ -92,7 +93,7 @@ describe('SelectionTabs', function () {
       fakeStore.selectedTab.returns('orphan');
       const wrapper = createComponent({});
       const tabs = wrapper.find('button');
-      assert.equal(tabs.length, 2);
+      assert.equal(tabs.length, 3);
     });
 
     it('should render `title` and `aria-label` attributes for tab buttons, with counts', () => {
@@ -200,6 +201,7 @@ describe('SelectionTabs', function () {
     { label: 'Annotations', tab: 'annotation' },
     { label: 'Page Notes', tab: 'note' },
     { label: 'Orphans', tab: 'orphan' },
+    { label: 'Doodles', tab: 'doodle' },
   ].forEach(({ label, tab }) => {
     it(`should change the selected tab when "${label}" tab is clicked`, () => {
       // Pre-select a different tab than the one we are about to click.

--- a/src/sidebar/helpers/annotation-metadata.js
+++ b/src/sidebar/helpers/annotation-metadata.js
@@ -236,6 +236,15 @@ export function isOrphan(annotation) {
 }
 
 /**
+ * Return `true` if the given annotation is a doodle.
+ *
+ * @param {Annotation} annotation
+ */
+export function isDoodle(annotation) {
+  return hasSelector(annotation) && annotation.$doodle === true;
+}
+
+/**
  * Return `true` if the given annotation is a page note.
  *
  * @param {Annotation} annotation

--- a/src/sidebar/helpers/tabs.js
+++ b/src/sidebar/helpers/tabs.js
@@ -18,6 +18,8 @@ export function tabForAnnotation(ann) {
     return 'orphan';
   } else if (metadata.isPageNote(ann)) {
     return 'note';
+  } else if (metadata.isDoodle(ann)) {
+    return 'doodle';
   } else {
     return 'annotation';
   }

--- a/src/sidebar/helpers/thread-annotations.js
+++ b/src/sidebar/helpers/thread-annotations.js
@@ -9,6 +9,7 @@ import { sorters } from './thread-sorters';
 /** @typedef {import('../../types/api').Annotation} Annotation */
 /** @typedef {import('./build-thread').Thread} Thread */
 /** @typedef {import('./build-thread').BuildThreadOptions} BuildThreadOptions */
+/** @typedef {import('../../types/sidebar').TabName} TabName */
 
 /**
  * @typedef ThreadState
@@ -20,7 +21,7 @@ import { sorters } from './thread-sorters';
  *   @prop {string[]} selection.forcedVisible
  *   @prop {string[]} selection.selected
  *   @prop {string} selection.sortKey
- *   @prop {'annotation'|'note'|'orphan'} selection.selectedTab
+ *   @prop {TabName} selection.selectedTab
  * @prop {string|null} route
  */
 

--- a/src/sidebar/services/annotations.js
+++ b/src/sidebar/services/annotations.js
@@ -119,7 +119,7 @@ export default function annotationsService(api, store) {
     } else if (metadata.isAnnotation(annotation)) {
       // if this is a doodle, select the doodle tab
       if (annotation.$doodle) {
-        store.selectTab('orphan');
+        store.selectTab('doodle');
       } else {
         store.selectTab('annotation');
       }

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -148,7 +148,9 @@ export default function FrameSync(annotationsService, bridge, store) {
       events_.forEach(function (event) {
         inFrame.add(event.tag);
         anchoringStatusUpdates[event.tag] = event.msg.$orphan
-          ? 'orphan'
+          ? event.msg.$doodle
+            ? 'doodle'
+            : 'orphan'
           : 'anchored';
         scheduleAnchoringStatusUpdate();
       });

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -145,13 +145,21 @@ export default function FrameSync(annotationsService, bridge, store) {
 
     // Anchoring an annotation in the frame completed
     bridge.on('sync', function (events_) {
+      const getAnchoringStatus = (orphan, doodle) => {
+        if (orphan) {
+          if (doodle) {
+            return 'doodle';
+          }
+          return 'orphan';
+        }
+        return 'anchored';
+      };
       events_.forEach(function (event) {
         inFrame.add(event.tag);
-        anchoringStatusUpdates[event.tag] = event.msg.$orphan
-          ? event.msg.$doodle
-            ? 'doodle'
-            : 'orphan'
-          : 'anchored';
+        anchoringStatusUpdates[event.tag] = getAnchoringStatus(
+          event.msg.$orphan,
+          event.msg.$doodle
+        );
         scheduleAnchoringStatusUpdate();
       });
     });

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -288,14 +288,22 @@ describe('sidebar/services/frame-sync', function () {
     });
 
     it('coalesces multiple "sync" messages', () => {
-      fakeBridge.emit('sync', [{ tag: 't1', msg: { $orphan: false } }]);
-      fakeBridge.emit('sync', [{ tag: 't2', msg: { $orphan: true } }]);
+      fakeBridge.emit('sync', [
+        { tag: 't1', msg: { $orphan: false, $doodle: false } },
+      ]);
+      fakeBridge.emit('sync', [
+        { tag: 't2', msg: { $orphan: true, $doodle: false } },
+      ]);
+      fakeBridge.emit('sync', [
+        { tag: 't3', msg: { $orphan: true, $doodle: true } },
+      ]);
 
       expireDebounceTimeout();
 
       assert.calledWith(fakeStore.updateAnchorStatus, {
         t1: 'anchored',
         t2: 'orphan',
+        t3: 'doodle',
       });
     });
   });

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -86,6 +86,7 @@ function initializeAnnotation(annotation, tag) {
     $anchorTimeout: false,
     $tag: annotation.$tag || tag,
     $orphan: orphan,
+    $doodle: annotation.$doodle,
   });
 }
 
@@ -544,6 +545,16 @@ const orphanCount = createSelector(
 );
 
 /**
+ * Count the number of doodles currently in the collection
+ *
+ * @type {(state: any) => number}
+ */
+const doodleCount = createSelector(
+  state => state.annotations,
+  annotations => countIf(annotations, metadata.isDoodle)
+);
+
+/**
  * Return all loaded annotations which have been saved to the server
  *
  * @return {Annotation[]}
@@ -583,6 +594,7 @@ export default storeModule({
     newHighlights,
     noteCount,
     orphanCount,
+    doodleCount,
     savedAnnotations,
   },
 });

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -196,10 +196,11 @@ const update = {
       if (!action.statusUpdates.hasOwnProperty(annot.$tag)) {
         return annot;
       }
-
       const state = action.statusUpdates[annot.$tag];
       if (state === 'timeout') {
         return Object.assign({}, annot, { $anchorTimeout: true });
+      } else if (state === 'doodle') {
+        return Object.assign({}, annot, { $doodle: true });
       } else {
         return Object.assign({}, annot, { $orphan: state === 'orphan' });
       }

--- a/src/sidebar/store/modules/selection.js
+++ b/src/sidebar/store/modules/selection.js
@@ -14,7 +14,7 @@
  *   @prop {string[]} forcedVisible
  *   @prop {string[]} selected
  *   @prop {string} sortKey
- *   @prop {'annotation'|'note'|'orphan'} selectedTab
+ *   @prop {TabName} selectedTab
  */
 
 import { createSelector } from 'reselect';

--- a/src/types/sidebar.js
+++ b/src/types/sidebar.js
@@ -12,7 +12,7 @@
  * The top-level tabs in the sidebar interface. Used to reference which tab
  * is currently selected (active/visible).
  *
- * @typedef {'annotation'|'note'|'orphan'} TabName
+ * @typedef {'annotation'|'note'|'orphan'|'doodle'} TabName
  */
 
 // Make TypeScript treat this file as a module.


### PR DESCRIPTION
This PR adds a tab for 'Doodles', so that they don't go to the 'Orphans' tab anymore. It also refactors the way that doodles are loaded, so that it is congruent with the rest of the hypothesis system. This should make the user interface a little easier to understand. The issue with the saving user interface is not addressed in this PR. 