### PR TITLE
Make Doodles Clickable

### DIFF
--- a/src/annotator/guest.js
+++ b/src/annotator/guest.js
@@ -802,7 +802,7 @@ export default class Guest extends Delegator {
    */
   clearDoodleCanvas() {
     if (this.doodleCanvasController) {
-      this.doodleCanvasController.saveLines();
+      this.doodleCanvasController.newLines = [];
     }
   }
 
@@ -820,9 +820,12 @@ export default class Guest extends Delegator {
         }
       }
     }
-    this.doodleCanvasController.savedLines = [
-      ...this.doodleCanvasController.savedLines,
-      ...newLines,
+    this.doodleCanvasController.savedDoodles = [
+      ...this.doodleCanvasController.savedDoodles,
+      {
+        $tag: doodleAnnotation.$tag,
+        lines: newLines,
+      },
     ];
   }
 }

--- a/src/annotator/sidebar.js
+++ b/src/annotator/sidebar.js
@@ -148,6 +148,10 @@ export default class Sidebar extends Guest {
         tool: 'pen',
         size: 5,
         color: 'red',
+      },
+      tag => {
+        this.crossframe?.call('showAnnotations', [tag]);
+        this.crossframe?.call('showSidebar');
       }
     );
 

--- a/src/doodle/canvas.js
+++ b/src/doodle/canvas.js
@@ -1,4 +1,4 @@
-import { createElement } from 'preact';
+import { createElement, Fragment } from 'preact';
 import { useRef, useEffect } from 'preact/hooks';
 import propTypes from 'prop-types';
 
@@ -10,14 +10,17 @@ const Canvas = ({
   handleMouseMove,
   handleMouseLeave,
   doodles,
+  handleDoodleClick,
 }) => {
   const canvasRef = useRef(null);
+  const hitCanvasRef = useRef(null);
 
-  const drawLine = (ctx, line) => {
+  const drawLine = (ctx, hitctx, line, colorHash) => {
     if (line.points.length <= 1) {
       return;
     }
     const [[startX, startY], ...rest] = line.points;
+    // Draw each line twice, once on the visible canvas, once on the 'hit' canvas
     // Move to the first point, begin the line
     ctx.beginPath();
     ctx.moveTo(startX, startY);
@@ -37,32 +40,104 @@ const Canvas = ({
 
     ctx.stroke();
     ctx.closePath();
+
+    // now draw the same line, but on our hit canvas
+    hitctx.beginPath();
+    hitctx.moveTo(startX, startY);
+    hitctx.lineWidth = line.size;
+
+    if (line.tool === 'pen') {
+      hitctx.globalCompositeOperation = 'source-over';
+      hitctx.strokeStyle = colorHash;
+    } else {
+      hitctx.globalCompositeOperation = 'destination-out';
+    }
+
+    // Draw the rest of the lines
+    for (let [x, y] of rest) {
+      hitctx.lineTo(x, y);
+    }
+
+    hitctx.stroke();
+    hitctx.closePath();
   };
+
+  const colorToTag = (r, g, b) => {
+    const tagNum = ((r << 16) | (g << 8) | b) - 1;
+    return `t${tagNum}`;
+  };
+
+  const tagToColor = tag => {
+    if (tag === 'none') {
+      // this is an untagged (in progress) doodle
+      return '#000000';
+    }
+    const tagNum = parseInt(tag.substring(1), 10) + 1;
+    return `#${tagNum.toString(16).padStart(6, '0')}`;
+  };
+
+  // have to add event listener this way because the canvas has pointerEvents = None
+  useEffect(() => {
+    const handleClick = e => {
+      const canvas = canvasRef.current;
+      const hitCanvas = hitCanvasRef.current;
+      const hitCtx = hitCanvas.getContext('2d');
+
+      // get the click coordinates
+      const offset = canvas.getBoundingClientRect();
+      const xPos = e.clientX - offset.left;
+      const yPos = e.clientY - offset.top;
+      // get the color of the pixel clicked on
+      const hitColor = hitCtx.getImageData(xPos, yPos, 1, 1).data;
+      // convert the color to a tag
+      const tag = colorToTag(hitColor[0], hitColor[1], hitColor[2]);
+      // call the click function with that tag. We offset tags to colors by 1 so that t-1 means there is no tag.
+      if (tag !== 't-1') {
+        handleDoodleClick(tag);
+      }
+    };
+
+    document.addEventListener('click', function (e) {
+      handleClick(e);
+    });
+  }, [handleDoodleClick]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
+    const hitCanvas = hitCanvasRef.current;
+    const hitctx = hitCanvas.getContext('2d');
+
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     // Draw all of the doodles
     for (let d = 0; d < doodles.length; d++) {
       const doodle = doodles[d];
+      let colorHash = tagToColor(doodle.$tag);
       // Draw all of the lines (reverse order so that erasing works)
       for (let i = doodle.lines.length - 1; i >= 0; i--) {
-        drawLine(ctx, doodle.lines[i]);
+        drawLine(ctx, hitctx, doodle.lines[i], colorHash);
       }
     }
   }, [doodles]);
 
   return (
-    <canvas
-      width={width}
-      height={height}
-      ref={canvasRef}
-      onMouseDown={handleMouseDown}
-      onMouseMove={handleMouseMove}
-      onMouseUp={handleMouseUp}
-      onMouseLeave={handleMouseLeave}
-    />
+    <Fragment>
+      <canvas
+        width={width}
+        height={height}
+        ref={canvasRef}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
+      />
+      <canvas
+        width={width}
+        height={height}
+        ref={hitCanvasRef}
+        style={{ visibility: 'hidden' }}
+      />
+    </Fragment>
   );
 };
 
@@ -73,6 +148,7 @@ Canvas.propTypes = {
   handleMouseUp: propTypes.func.isRequired,
   handleMouseMove: propTypes.func.isRequired,
   handleMouseLeave: propTypes.func.isRequired,
+  handleDoodleClick: propTypes.func.isRequired,
   doodles: propTypes.array.isRequired,
 };
 

--- a/src/doodle/canvas.js
+++ b/src/doodle/canvas.js
@@ -9,7 +9,7 @@ const Canvas = ({
   handleMouseUp,
   handleMouseMove,
   handleMouseLeave,
-  lines,
+  doodles,
 }) => {
   const canvasRef = useRef(null);
 
@@ -43,12 +43,15 @@ const Canvas = ({
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    // Draw all of the lines (reverse order so that erasing works)
-    for (let i = lines.length - 1; i >= 0; i--) {
-      drawLine(ctx, lines[i]);
+    // Draw all of the doodles
+    for (let d = 0; d < doodles.length; d++) {
+      const doodle = doodles[d];
+      // Draw all of the lines (reverse order so that erasing works)
+      for (let i = doodle.lines.length - 1; i >= 0; i--) {
+        drawLine(ctx, doodle.lines[i]);
+      }
     }
-  }, [lines]);
+  }, [doodles]);
 
   return (
     <canvas
@@ -70,7 +73,7 @@ Canvas.propTypes = {
   handleMouseUp: propTypes.func.isRequired,
   handleMouseMove: propTypes.func.isRequired,
   handleMouseLeave: propTypes.func.isRequired,
-  lines: propTypes.array.isRequired,
+  doodles: propTypes.array.isRequired,
 };
 
 export { Canvas };

--- a/src/doodle/canvas.js
+++ b/src/doodle/canvas.js
@@ -84,16 +84,25 @@ const Canvas = ({
       const hitCtx = hitCanvas.getContext('2d');
 
       // get the click coordinates
-      const offset = canvas.getBoundingClientRect();
-      const xPos = e.clientX - offset.left;
-      const yPos = e.clientY - offset.top;
-      // get the color of the pixel clicked on
-      const hitColor = hitCtx.getImageData(xPos, yPos, 1, 1).data;
-      // convert the color to a tag
-      const tag = colorToTag(hitColor[0], hitColor[1], hitColor[2]);
-      // call the click function with that tag. We offset tags to colors by 1 so that t-1 means there is no tag.
-      if (tag !== 't-1') {
-        handleDoodleClick(tag);
+      const boundingBox = canvas.getBoundingClientRect();
+      const xPos = e.clientX - boundingBox.left;
+      const yPos = e.clientY - boundingBox.top;
+
+      // make sure that this click happened inside the canvas
+      if (
+        xPos > 0 &&
+        xPos < boundingBox.width &&
+        yPos > 0 &&
+        yPos > boundingBox.height
+      ) {
+        // get the color of the pixel clicked ony
+        const hitColor = hitCtx.getImageData(xPos, yPos, 1, 1).data;
+        // convert the color to a tag
+        const tag = colorToTag(hitColor[0], hitColor[1], hitColor[2]);
+        // call the click function with that tag. We offset tags to colors by 1 so that t-1 means there is no tag.
+        if (tag !== 't-1') {
+          handleDoodleClick(tag);
+        }
       }
     };
 

--- a/src/doodle/displayCanvas.js
+++ b/src/doodle/displayCanvas.js
@@ -1,8 +1,18 @@
 import { createElement } from 'preact';
 import { Canvas } from './canvas';
 import propTypes from 'prop-types';
+/**
+ * @typedef DisplayCanvasProps
+ * @prop {HTMLElement} container - Which element the DisplayCanvas should cover.
+ * @prop {Array<import('../types/api').Doodle>} doodles - An array of Doodles to render
+ */
 
-const DisplayCanvas = ({ container, lines }) => {
+/**
+ * Component that renders saved Doodle annotations
+ *
+ * @param {DisplayCanvasProps} props
+ */
+const DisplayCanvas = ({ container, doodles }) => {
   const boundingRect = container.getBoundingClientRect();
   return (
     <div
@@ -26,14 +36,14 @@ const DisplayCanvas = ({ container, lines }) => {
         handleMouseUp={() => {}}
         handleMouseLeave={() => {}}
         handleMouseMove={() => {}}
-        lines={lines}
+        doodles={doodles}
       />
     </div>
   );
 };
 
 DisplayCanvas.propTypes = {
-  lines: propTypes.array.isRequired,
+  doodles: propTypes.array.isRequired,
   container: propTypes.object.isRequired,
 };
 

--- a/src/doodle/displayCanvas.js
+++ b/src/doodle/displayCanvas.js
@@ -5,6 +5,7 @@ import propTypes from 'prop-types';
  * @typedef DisplayCanvasProps
  * @prop {HTMLElement} container - Which element the DisplayCanvas should cover.
  * @prop {Array<import('../types/api').Doodle>} doodles - An array of Doodles to render
+ * @prop {(String) => any} handleDoodleClick - What to do when a doodle is clicked? Accepts the Doodle's `tag` as a prop
  */
 
 /**
@@ -12,7 +13,7 @@ import propTypes from 'prop-types';
  *
  * @param {DisplayCanvasProps} props
  */
-const DisplayCanvas = ({ container, doodles }) => {
+const DisplayCanvas = ({ container, doodles, handleDoodleClick }) => {
   const boundingRect = container.getBoundingClientRect();
   return (
     <div
@@ -37,6 +38,7 @@ const DisplayCanvas = ({ container, doodles }) => {
         handleMouseLeave={() => {}}
         handleMouseMove={() => {}}
         doodles={doodles}
+        handleDoodleClick={handleDoodleClick}
       />
     </div>
   );
@@ -45,6 +47,7 @@ const DisplayCanvas = ({ container, doodles }) => {
 DisplayCanvas.propTypes = {
   doodles: propTypes.array.isRequired,
   container: propTypes.object.isRequired,
+  handleDoodleClick: propTypes.func.isRequired,
 };
 
 export { DisplayCanvas };

--- a/src/doodle/doodleCanvas.js
+++ b/src/doodle/doodleCanvas.js
@@ -122,6 +122,7 @@ const DoodleCanvas = ({
         handleMouseLeave={handleMouseLeave}
         handleMouseMove={handleMouseMove}
         doodles={[{ $tag: 'none', lines: lines }]}
+        handleDoodleClick={() => {}}
       />
     </div>
   );

--- a/src/doodle/doodleCanvas.js
+++ b/src/doodle/doodleCanvas.js
@@ -15,11 +15,7 @@ import propTypes from 'prop-types';
  */
 
 /**
- * Component that renders icons using inline `<svg>` elements.
- * This enables their appearance to be customized via CSS.
- *
- * This matches the way we do icons on the website, see
- * https://github.com/hypothesis/h/pull/3675
+ * Component that renders a canvas for users to draw Doodles on.
  *
  * @param {DoodleCanvasProps} props
  */
@@ -33,6 +29,11 @@ const DoodleCanvas = ({
   setLines,
 }) => {
   const [isDrawing, setIsDrawing] = useState(false);
+  const [everActive, setEverActive] = useState(false);
+
+  if (active && !everActive) {
+    setEverActive(true);
+  }
 
   useEffect(() => {
     if (lines.length === 0) {
@@ -93,6 +94,10 @@ const DoodleCanvas = ({
     setLines([newLine, ...rest]);
   };
 
+  if (!everActive) {
+    return null;
+  }
+
   return (
     <div
       style={{
@@ -116,7 +121,7 @@ const DoodleCanvas = ({
         handleMouseUp={handleMouseUp}
         handleMouseLeave={handleMouseLeave}
         handleMouseMove={handleMouseMove}
-        lines={lines}
+        doodles={[{ $tag: 'none', lines: lines }]}
       />
     </div>
   );
@@ -126,9 +131,9 @@ DoodleCanvas.propTypes = {
   tool: propTypes.string.isRequired,
   size: propTypes.number.isRequired,
   active: propTypes.bool.isRequired,
+  color: propTypes.string.isRequired,
   lines: propTypes.array.isRequired,
   setLines: propTypes.func.isRequired,
-  color: propTypes.string.isRequired,
   attachedElement: propTypes.any.isRequired,
 };
 

--- a/src/doodle/doodleController.js
+++ b/src/doodle/doodleController.js
@@ -91,13 +91,6 @@ export class DoodleController {
     return this._doodleable;
   }
 
-  //TODO: can we get rid of this?
-  // saveLines() {
-  //   this._savedLines = [...this._newLines, ...this._savedLines];
-  //   this._newLines = [];
-  //   this.render();
-  // }
-
   render() {
     const setLines = lines => {
       this.newLines = lines;

--- a/src/doodle/doodleController.js
+++ b/src/doodle/doodleController.js
@@ -10,7 +10,7 @@ export class DoodleController {
   constructor(container, options) {
     const { tool, size, color } = options;
     this._lines = [];
-    this._savedLines = [];
+    this._savedDoodles = [];
     this._newLines = [];
 
     this._container = container === null ? document.body : container;
@@ -41,13 +41,13 @@ export class DoodleController {
   /**
    * Update the lines and re-render on change
    */
-  set savedLines(lines) {
-    this._savedLines = lines;
+  set savedDoodles(lines) {
+    this._savedDoodles = lines;
     this.render();
   }
 
-  get savedLines() {
-    return this._savedLines;
+  get savedDoodles() {
+    return this._savedDoodles;
   }
 
   set newLines(lines) {
@@ -90,11 +90,12 @@ export class DoodleController {
     return this._doodleable;
   }
 
-  saveLines() {
-    this._savedLines = [...this._newLines, ...this._savedLines];
-    this._newLines = [];
-    this.render();
-  }
+  //TODO: can we get rid of this?
+  // saveLines() {
+  //   this._savedLines = [...this._newLines, ...this._savedLines];
+  //   this._newLines = [];
+  //   this.render();
+  // }
 
   render() {
     const setLines = lines => {
@@ -111,7 +112,10 @@ export class DoodleController {
           setLines={setLines}
           color={this._color}
         />
-        <DisplayCanvas lines={this.savedLines} container={this._container} />
+        <DisplayCanvas
+          doodles={this.savedDoodles}
+          container={this._container}
+        />
       </Fragment>,
       this.target
     );

--- a/src/doodle/doodleController.js
+++ b/src/doodle/doodleController.js
@@ -7,7 +7,7 @@ export class DoodleController {
    * @param {HTMLElement | null} container - Element into which the toolbar is rendered
    * @param {any} options
    */
-  constructor(container, options) {
+  constructor(container, options, handleDoodleClick) {
     const { tool, size, color } = options;
     this._lines = [];
     this._savedDoodles = [];
@@ -19,6 +19,7 @@ export class DoodleController {
     this._color = color;
 
     this._doodleable = false;
+    this._handleDoodleClick = handleDoodleClick;
 
     // create a new element to render into, to avoid overwriting the main page content.
     this.target = document.body.appendChild(document.createElement('div'));
@@ -113,6 +114,7 @@ export class DoodleController {
           color={this._color}
         />
         <DisplayCanvas
+          handleDoodleClick={this._handleDoodleClick}
           doodles={this.savedDoodles}
           container={this._container}
         />

--- a/src/sidebar/components/SidebarView.js
+++ b/src/sidebar/components/SidebarView.js
@@ -56,6 +56,7 @@ function SidebarView({
   const searchUris = store.searchUris();
   const sidebarHasOpened = store.hasSidebarOpened();
   const userId = store.profile().userid;
+  //WILLNOTE we can use this to hide/show for this user!
 
   // The local `$tag` of a direct-linked annotation; populated once it
   // has anchored: meaning that it's ready to be focused and scrolled to

--- a/src/sidebar/services/frame-sync.js
+++ b/src/sidebar/services/frame-sync.js
@@ -166,7 +166,7 @@ export default function FrameSync(annotationsService, bridge, store) {
 
     bridge.on('showAnnotations', function (tags) {
       store.selectAnnotations(store.findIDsForTags(tags));
-      store.selectTab('annotation');
+      store.selectTab(store.findTypeForTags(tags));
     });
 
     bridge.on('focusAnnotations', function (tags) {

--- a/src/sidebar/services/test/frame-sync-test.js
+++ b/src/sidebar/services/test/frame-sync-test.js
@@ -64,6 +64,7 @@ describe('sidebar/services/frame-sync', function () {
         isLoggedIn: sinon.stub().returns(false),
         openSidebarPanel: sinon.stub(),
         selectAnnotations: sinon.stub(),
+        findTypeForTags: sinon.stub(),
         selectTab: sinon.stub(),
         setSidebarOpened: sinon.stub(),
         toggleSelectedAnnotations: sinon.stub(),
@@ -342,10 +343,22 @@ describe('sidebar/services/frame-sync', function () {
   describe('on "showAnnotations" message', function () {
     it('selects annotations which have an ID', function () {
       fakeStore.findIDsForTags.returns(['id1', 'id2', 'id3']);
+      fakeStore.findTypeForTags.returns('annotation');
       fakeBridge.emit('showAnnotations', ['tag1', 'tag2', 'tag3']);
 
       assert.calledWith(fakeStore.selectAnnotations, ['id1', 'id2', 'id3']);
       assert.calledWith(fakeStore.selectTab, 'annotation');
+    });
+  });
+
+  describe('on "showAnnotations" message with doodles', function () {
+    it('selects annotations which have an ID', function () {
+      fakeStore.findIDsForTags.returns(['id1', 'id2', 'id3']);
+      fakeStore.findTypeForTags.returns('doodle');
+      fakeBridge.emit('showAnnotations', ['tag1', 'tag2', 'tag3']);
+
+      assert.calledWith(fakeStore.selectAnnotations, ['id1', 'id2', 'id3']);
+      assert.calledWith(fakeStore.selectTab, 'doodle');
     });
   });
 

--- a/src/sidebar/store/modules/annotations.js
+++ b/src/sidebar/store/modules/annotations.js
@@ -443,6 +443,13 @@ function findAnnotationByID(state, id) {
 }
 
 /**
+ * Return the annotations with a given User
+ */
+function findAnnotationsByUser(state, user) {
+  return state.annotations.filter(a => a.user === user);
+}
+
+/**
  * Return the IDs of annotations that correspond to `tags`.
  *
  * If an annotation does not have an ID because it has not been created on
@@ -459,6 +466,22 @@ function findIDsForTags(state, tags) {
     }
   });
   return ids;
+}
+
+/**
+ * Return the type of the *first* saved annotation that corresponds to `tags`
+ *
+ * @param {string[]} tags - Local tags of annotations to look up
+ */
+function findTypeForTags(state, tags) {
+  for (const tag of tags) {
+    const annot = findByTag(state.annotations, tag);
+    if (annot && annot.id) {
+      return annot.$doodle ? 'doodle' : 'annotation';
+    }
+  }
+  // default to 'annotation'
+  return 'annotation';
 }
 
 /**
@@ -586,7 +609,9 @@ export default storeModule({
     annotationCount,
     annotationExists,
     findAnnotationByID,
+    findAnnotationsByUser,
     findIDsForTags,
+    findTypeForTags,
     focusedAnnotations,
     highlightedAnnotations,
     isAnnotationFocused,

--- a/src/sidebar/util/test/disable-opener-for-external-links-test.js
+++ b/src/sidebar/util/test/disable-opener-for-external-links-test.js
@@ -20,6 +20,8 @@ describe('sidebar.util.disable-opener-for-external-links', () => {
       new Event('click', {
         bubbles: true,
         cancelable: true,
+        clientX: 0,
+        clientY: 0,
       })
     );
   }

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -54,6 +54,12 @@
  */
 
 /**
+ * @typedef Doodle
+ * @prop {string} $tag
+ * @prop {Array<DoodleLine>} lines
+ */
+
+/**
  * TODO - Fill out remaining properties
  *
  * @typedef Annotation


### PR DESCRIPTION
This PR makes doodles clickable. Now, when a doodle is clicked, it opens up the sidebar with only the annotation for that doodle. This matches the functionality of clicking on a highlight or non-doodle annotation.