### PR TITLE
Attach doodles to elements

### DIFF
--- a/src/doodle/doodleCanvas.js
+++ b/src/doodle/doodleCanvas.js
@@ -11,9 +11,9 @@ import propTypes from 'prop-types';
  * @prop {string} color - The color of the brush
  * @prop {HTMLElement} attachedElement - Which element the DoodleCanvas should cover.
  * @prop {Array<import('../types/api').DoodleLine>} lines - An array of lines that compose this doodle.
- * @prop {Function} setLines - A function to set the lines
- * @prop {Function} onUndo - a function called when undo key commands pressed
- * @prop {Function} onRedo - a function called when redo key commands pressed
+ * @prop {(lines: import('../types/api').DoodleLine[]) => void} setLines - A function to set the lines
+ * @prop {() => void} onUndo - a function called when undo key commands pressed
+ * @prop {() => void} onRedo - a function called when redo key commands pressed
  */
 
 /**
@@ -84,6 +84,11 @@ const DoodleCanvas = ({
         tool: tool,
         color: color,
         size: size,
+        elem: {
+          path: '',
+          height: 0,
+          width: 0,
+        },
         points: [[e.offsetX, e.offsetY]],
       },
       ...lines,
@@ -109,10 +114,9 @@ const DoodleCanvas = ({
     const xPos = e.offsetX;
     const yPos = e.offsetY;
 
+    /** @type {import('../types/annotator').DoodleLine} */
     const newLine = {
-      tool: curLine.tool,
-      color: curLine.color,
-      size: curLine.size,
+      ...curLine,
       points: [[xPos, yPos], ...curLine.points],
     };
 

--- a/src/doodle/doodleController.js
+++ b/src/doodle/doodleController.js
@@ -9,12 +9,19 @@ export class DoodleController {
    */
   constructor(container, options, handleDoodleClick) {
     const { tool, size, color } = options;
+    /** @type {import('../types/api').DoodleLine[]} */
+
     this._lines = [];
+    /** @type {import('../types/api').Doodle[]} */
+
     this._savedDoodles = [];
+    /** @type {import('../types/api').DoodleLine[]} */
     this._newLines = [];
+    /** @type {import('../types/api').DoodleLine[]} */
+
     this._redoLines = [];
 
-    this._container = container === null ? document.body : container;
+    this.container = container === null ? document.body : container;
     this._tool = tool;
     this._size = size;
     this._color = color;
@@ -107,12 +114,14 @@ export class DoodleController {
 
   undo() {
     if (this._newLines.length) {
+      // @ts-ignore shift won't return undefined due to length check
       this._redoLines.push(this._newLines.shift());
       this.render();
     }
   }
   redo() {
     if (this._redoLines.length) {
+      // @ts-ignore pop won't return undefined due to length check
       this._newLines = [this._redoLines.pop(), ...this._newLines];
       this.render();
     }
@@ -125,7 +134,7 @@ export class DoodleController {
     render(
       <Fragment>
         <DoodleCanvas
-          attachedElement={this._container}
+          attachedElement={this.container}
           size={this._size}
           tool={this._tool}
           active={this._doodleable}
@@ -138,7 +147,7 @@ export class DoodleController {
         <DisplayCanvas
           handleDoodleClick={this._handleDoodleClick}
           doodles={this.savedDoodles}
-          container={this._container}
+          container={this.container}
           showDoodles={this._showDoodles}
         />
       </Fragment>,

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -46,10 +46,17 @@
  */
 
 /**
+ * @typedef DoodleElem
+ * @prop {string} path
+ * @prop {number} height
+ * @prop {number} width
+ */
+/**
  * @typedef DoodleLine
  * @prop {string} tool
  * @prop {string} color
- * @prop {string} size
+ * @prop {number} size
+ * @prop {DoodleElem} elem
  * @prop {Array<Array<number>>} points
  */
 


### PR DESCRIPTION
HELL YEAH THIS IS MAGIC

Tested on https://en.wikipedia.org/wiki/Test as they have some nice display: fixed stuff to move around easily.

Effectively, when saving a doodle, it finds what element it's "attached" to by determining what the smallest element (by area) containing >=75% of it's points, then converts all coordinates to be relative to that. When loading, it'll then find that element again and re-convert coordinates back to global. Also, there's a couple lines of code to handle what happens when that element changes size too. 

Changes in PointResolver class were to fix a subtle bug with finding points, which is kind of hard to describe exactly, but essentially involved some elements being much shorter than they should have been when determining click locations, due to an issue with them not being added to the bottom half of splits. If someone wants, I can give an example.

Also cleaned up various type definitions so intellisense worked.

http://platinum.cscaws.com:8080/browse/CREAT-145
